### PR TITLE
Fix Arraypack unminified nodes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,11 +53,11 @@ export function toArrayPack(node: MinifiedLexicalNode) {
 
   const { t, v, c, ...props } = node;
 
-  if (t !== "r") {
+  if (typeof t === "string" && t !== "r") {
     pack.push(t);
   }
 
-  if (v !== 1) {
+  if (typeof v === "number" && v !== 1) {
     pack.push(v);
   }
 
@@ -77,10 +77,7 @@ export function toArrayPack(node: MinifiedLexicalNode) {
  * @returns The transformed MinifiedLexicalNode.
  */
 export function fromArrayPack(pack: ArrayPackNode) {
-  let node: MinifiedLexicalNode = {
-    t: "r",
-    v: 1,
-  };
+  let node: any = {};
 
   pack.forEach((element) => {
     if (typeof element === "string") {
@@ -93,5 +90,14 @@ export function fromArrayPack(pack: ArrayPackNode) {
       node = { ...node, ...element };
     }
   });
-  return node;
+
+  if (typeof node.t === "undefined" && typeof node.type === "undefined") {
+    node.t = "r";
+  }
+  if (typeof node.v === "undefined" && typeof node.version === "undefined") {
+    node.v = 1;
+  }
+
+  // Consider rewriting the types as MaybeMinifiedLexicalNode to properly type non-minified nodes
+  return node as MinifiedLexicalNode;
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -10,13 +10,74 @@ import {
   ListItemNode,
   ListNode,
 } from "@lexical/list";
-import { $createParagraphNode, $createTextNode, $getRoot } from "lexical";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  NodeKey,
+  SerializedTextNode,
+  TextNode,
+} from "lexical";
 import { $createLinkNode, LinkNode, AutoLinkNode } from "@lexical/link";
 import { CodeNode, CodeHighlightNode } from "@lexical/code";
 import { TableNode, TableRowNode, TableCellNode } from "@lexical/table";
 
 import { createHeadlessEditor } from "@lexical/headless";
 import { fromArrayPack, minify, toArrayPack, unminify } from "../src/utils";
+
+export class ColoredNode extends TextNode {
+  __color: string;
+
+  constructor(text: string, color: string, key?: NodeKey) {
+    super(text, key);
+    this.__color = color;
+  }
+
+  static getType(): string {
+    return "colored-node";
+  }
+
+  exportJSON() {
+    return {
+      type: "colored-node",
+      version: 1,
+      color: this.__color,
+    } as unknown as SerializedTextNode;
+  }
+}
+
+function $createColoredNode(text: string, color: string) {
+  return new ColoredNode(text, color);
+}
+
+const REGISTERED_NODES = [
+  ColoredNode,
+  HeadingNode,
+  ListNode,
+  ListItemNode,
+  QuoteNode,
+  CodeNode,
+  CodeHighlightNode,
+  TableNode,
+  TableCellNode,
+  TableRowNode,
+  AutoLinkNode,
+  LinkNode,
+];
+
+function prepopulatedTextWithCustomNode() {
+  const root = $getRoot();
+
+  const heading = $createHeadingNode("h1");
+  heading.append($createTextNode("Welcome to the Markdown example"));
+  root.append(heading);
+
+  const paragraph = $createParagraphNode();
+  const customNode = $createColoredNode("This is a custom node", "red");
+
+  paragraph.append(customNode);
+  root.append(paragraph);
+}
 
 export default function prepopulatedText() {
   const root = $getRoot();
@@ -65,34 +126,54 @@ export default function prepopulatedText() {
   );
   root.append(paragraph3);
 }
+const consoleInfoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
 describe("text-minifier-utils", () => {
   it("should minify and unminify editor data correctly", async () => {
     const editor = createHeadlessEditor({
-      nodes: [
-        HeadingNode,
-        ListNode,
-        ListItemNode,
-        QuoteNode,
-        CodeNode,
-        CodeHighlightNode,
-        TableNode,
-        TableCellNode,
-        TableRowNode,
-        AutoLinkNode,
-        LinkNode,
-      ],
+      nodes: REGISTERED_NODES,
     });
     await editor.update(prepopulatedText);
     const editorState = editor.getEditorState().toJSON();
 
-    editor.update(() => {
-      const minified = minify($getRoot());
-      const serialized = unminify(minified);
-      const arrayPack = toArrayPack(minified);
+    return new Promise<void>(async (done) => {
+      await editor.update(() => {
+        const minified = minify($getRoot());
+        const serialized = unminify(minified);
+        const arrayPack = toArrayPack(minified);
 
-      expect(minified).toEqual(fromArrayPack(arrayPack));
-      expect(serialized).toEqual(editorState.root);
+        expect(minified).toEqual(fromArrayPack(arrayPack));
+        expect(serialized).toEqual(editorState.root);
+        done();
+      });
+    });
+  });
+
+  it("should skip unregistered node types", async () => {
+    const editor = createHeadlessEditor({
+      nodes: REGISTERED_NODES,
+    });
+    await editor.update(prepopulatedTextWithCustomNode);
+    const editorState = editor.getEditorState().toJSON();
+
+    return new Promise<void>(async (done) => {
+      await editor.update(() => {
+        const minified = minify($getRoot());
+        const serialized = unminify(minified);
+        const arrayPack = toArrayPack(minified);
+
+        expect(minified).toEqual(fromArrayPack(arrayPack));
+        expect(serialized).toEqual(editorState.root);
+        expect(consoleInfoSpy).toHaveBeenCalledWith(
+          'No minifiers are registered for type:"colored-node", version:1. Keeping original value.',
+        );
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "No minifier was found for type colored-node.",
+        );
+
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
The `toArrayPack` and `fromArrayPack` utilities only handled minified nodes. 
This PR enables using the ArrayPack format with non-minified nodes.

Fixes https://github.com/fedemartinm/lexical-minifier/issues/2
